### PR TITLE
update to lodash 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/screeps/storage.git"
   },
   "dependencies": {
-    "lodash": "^3.10.1",
+    "lodash": "^4.0.0",
     "lokijs": "^1.5.6",
     "q": "^1.4.1"
   }


### PR DESCRIPTION
Updates lodash to version 4.

A review of the code indicates that no other parts are affected by the breaking changes in the library update.