### PR TITLE
🔨 Fix a crash if the Loki initialization is entirely skipped

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -24,6 +24,7 @@ Object.assign(config.storage, {
     },
     loadDb() {
         db = config.storage.getDb();
+        installCleanupTimer();
         return q.ninvoke(db, 'loadDatabase', {})
             .then(upgradeDb);
     }
@@ -292,28 +293,31 @@ function updateDocument(doc, update) {
     }
 }
 
-setInterval(function envCleanExpired() {
-    var env = db.getCollection('env');
-    var values = env.get(1);
-    var expiration = env.get(2);
-    var dirty = false;
-    if (expiration) {
-        for (var name in expiration.data) {
-            if (Date.now() > expiration.data[name]) {
-                dirty = true;
-                if (values.data[name]) {
-                    delete values.data[name];
+function installCleanupTimer() {
+    setInterval(function envCleanExpired() {
+        if (!db) return;
+        var env = db.getCollection('env');
+        var values = env.get(1);
+        var expiration = env.get(2);
+        var dirty = false;
+        if (expiration) {
+            for (var name in expiration.data) {
+                if (Date.now() > expiration.data[name]) {
+                    dirty = true;
+                    if (values.data[name]) {
+                        delete values.data[name];
+                    }
+                    delete expiration.data[name];
                 }
-                delete expiration.data[name];
             }
         }
-    }
-    if (dirty) {
-        env.update(values);
-        env.update(expiration);
-    }
-}, 10000);
-
+        if (dirty) {
+            env.update(values);
+            env.update(expiration);
+        }
+    }, 10000);
+}
+    
 function getRandomString() {
     for (var val = Math.floor(Math.random() * 0x10000).toString(16); val.length < 4; val = '0' + val);
     return val;


### PR DESCRIPTION
I just hit that case with the screepsmod-mongo that just completely skips over the LokiJS initialization. As this `setTimeout` is at the top-level, there's no way to make it not happen.

Fix the issue by moving the timer into a setup function, and only calling that if Loki gets initialized.